### PR TITLE
Add Covid Widgets KWGT

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@
 |[COVID-19 Tracker](https://github.com/prateekKrOraon/covid19_tracker) | Android Application made with Flutter shows global COVID-19 statistics primarily focusing on India. The app also provides predictions (India only) using SIRD model of epidemiology and has a feature to compare spread trends of any two countries. | [prateekKrOraon](https://github.com/prateekKrOraon) | English & Hindi
 | [NumOMeter](https://play.google.com/store/apps/details?id=com.app.numometer) | This project, an Android based application made with Flutter, has been made with the use of some great open-source projects that have been providing some latest numbers in accordance with the recent situation. I have tried to put all those numbers in a single application for the better user experience. | [neo7337](https://github.com/neo7337) | English
 | [COVID-19 Tracker CR](https://github.com/TotallyNotInUse/covid_tracker_cr/releases/latest) | This app is for tracking information related to COVID-19 in Costa Rica only. Made in Flutter and for Android. | [TotallyNotInUse {Julian Murillo}](https://github.com/TotallyNotInUse) | Spanish
+| [Covid Widgets KWGT](https://github.com/yogeshgosavi/Covid-Widgets-KWGT) | Get Covid statistics right on your homescreen. | [yogeshgosavi](https://github.com/yogeshgosavi) | English
 
 ## Desktop Applications
 


### PR DESCRIPTION
This widget allows checking COVID stats directly on Android Homescreen. 
a lot of people have been using this widget to check COVID stats, updated now to use V3 endpoints. 