### PR TITLE
Add: Covid Today native Android app

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@
 | [COVID-19 Tracker CR](https://github.com/TotallyNotInUse/covid_tracker_cr/releases/latest) | This app is for tracking information related to COVID-19 in Costa Rica only. Made in Flutter and for Android. | [TotallyNotInUse {Julian Murillo}](https://github.com/TotallyNotInUse) | Spanish
 | [Covid Widgets KWGT](https://github.com/yogeshgosavi/Covid-Widgets-KWGT) | Get Covid statistics right on your homescreen. | [yogeshgosavi](https://github.com/yogeshgosavi) | English
 | [Covid-19 Cases Tracker](https://github.com/adityanjr/covid19-tracker) | Tracking the impact of COVID-19 cases based on your location, built in Flutter. | [adityanjr](https://github.com/adityanjr) | English
+| [Covid Today](https://install.appcenter.ms/users/info-145/apps/covid-today/distribution_groups/everybody) | Native Android app written in Kotlin with a card view layout showing today's cases by country. Based on the [web](https://codepen.io/tinacious/full/eYNbEoE) version. [Open-source](https://github.com/tinacious/CovidToday-Android). | [tinacious](https://github.com/tinacious) | Multiple
 
 ## Desktop Applications
 


### PR DESCRIPTION
**Covid Today** is a native Android application written in Kotlin. The source code is open and there's an AppCenter build you can download.

- [Github repo](https://github.com/tinacious/CovidToday-Android)
- [AppCenter build](https://install.appcenter.ms/users/info-145/apps/covid-today/distribution_groups/everybody)

Supported languages:

- English
- French
- Spanish